### PR TITLE
Add Dockerfile for ROS 2 Humble

### DIFF
--- a/docker/Dockerfile.foxy
+++ b/docker/Dockerfile.foxy
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     locales \
     python3 \
     python3-pip \
+    python3-dev \
     sudo \
     x11-apps \
     zenity \

--- a/docker/Dockerfile.humble
+++ b/docker/Dockerfile.humble
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.6.0-devel-ubuntu24.04
+FROM nvidia/cuda:12.6.0-cudnn-devel-ubuntu22.04
 LABEL maintainer="Shady Gmira <shady.gmira@gmail.com>"
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     x11-apps \
     zenity \
     openssh-client \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
+    && apt-get clean && rm -rf /var/lib/apt/lists/* && apt --fix-missing install -y 
 
 # Locale
 RUN locale-gen en_US.UTF-8 && \
@@ -28,7 +28,7 @@ RUN locale-gen en_US.UTF-8 && \
 ENV LANG=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
-ENV ROS_DISTRO=jazzy
+ENV ROS_DISTRO=humble
 
 # ROS 2 setup
 RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key | \
@@ -36,32 +36,48 @@ gpg --dearmor -o /usr/share/keyrings/ros-archive-keyring.gpg && \
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" \
 > /etc/apt/sources.list.d/ros2.list
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ros-${ROS_DISTRO}-desktop \
+RUN apt-get clean && apt-get update && apt-get --fix-broken install -y --no-install-recommends \
+    ros-${ROS_DISTRO}-ros-base \
     python3-colcon-common-extensions \
     ros-dev-tools \
+    ros-humble-rmw-cyclonedds-cpp \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Python requirements
-COPY ./docker/requirements-docker.txt requirements.txt
-RUN pip install --no-cache-dir --break-system-packages --ignore-installed imgui-bundle
-RUN pip install --no-cache-dir --break-system-packages --ignore-installed -r requirements.txt
-
-# Change this env variable to your own system requirements
-ENV TORCH_CUDA_ARCH_LIST="8.6" 
-RUN pip install --break-system-packages git+https://github.com/nerfstudio-project/gsplat.git
-
-RUN pip install --break-system-packages "numpy<2"
-
-# OpenGL & NVIDIA driver integration (Ubuntu 24.04, Driver 550)
+# GUI applications
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libglvnd-dev \
     libgl1 \
     libglx0 \
     libegl1 \
     libx11-6 \
+    libx11-dev \
+    libxext-dev \
+    libxrandr-dev \      
+    libxinerama-dev \    
+    libxcursor-dev \
+    libxi-dev \     
     libglfw3-dev \
-    mesa-utils
+    mesa-utils \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.29.2/cmake-3.29.2-linux-x86_64.sh -O /cmake-install.sh && \
+    chmod +x /cmake-install.sh && \
+    /cmake-install.sh --skip-license --prefix=/usr/local
+
+ENV CMAKE_EXECUTABLE=/usr/local/bin/cmake
+
+# Python requirements
+COPY ./docker/requirements-docker.txt requirements.txt
+RUN pip install --upgrade pip  setuptools wheel scikit-build scikit-build-core importlib-metadata packaging pybind11 nanobind
+RUN pip install --no-build-isolation imgui-bundle
+RUN pip install --no-cache-dir  --ignore-installed -r requirements.txt
+
+# Change this env variable to your own system requirements
+ENV TORCH_CUDA_ARCH_LIST="8.6" 
+RUN pip install git+https://github.com/nerfstudio-project/gsplat.git
+
+RUN pip install "numpy<2"
+
 
 ARG USER_UID
 ARG USER_GID

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -33,6 +33,7 @@ services:
       - SSH_AUTH_SOCK=${SSH_AUTH_SOCK}
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=all
+      - RMW_IMPLEMENTATION=${RMW_IMPLEMENTATION}
     volumes:
       - ../:/home/${USERNAME}/projects/ROSplat
       - /tmp/.X11-unix:/tmp/.X11-unix:rw

--- a/docker/requirements-docker.txt
+++ b/docker/requirements-docker.txt
@@ -14,4 +14,5 @@ setuptools
 catkin_pkg
 lark
 jinja2
+cv_bridge
 typeguard

--- a/docker/run_docker.sh
+++ b/docker/run_docker.sh
@@ -9,6 +9,7 @@ usage() {
     echo " -c    Stop and clean up"
     echo " -j    Use ROS 2 Jazzy (default)"
     echo " -f    Use ROS 2 Foxy"
+    echo " -l    Use ROS 2 Humble"
 }
 
 if [ "$#" -lt 1 ]; then
@@ -22,7 +23,7 @@ BUILD=false
 BUILD_ARGS=""
 COMPOSEUP=false
 
-while getopts "hbnucjf" opt; do
+while getopts "hbnucjfl" opt; do
     case ${opt} in
         h ) usage; exit 0 ;;
         b ) BUILD=true ;;
@@ -31,6 +32,7 @@ while getopts "hbnucjf" opt; do
         c ) docker compose down --remove-orphans; exit 0 ;;
         j ) DOCKERFILE="docker/Dockerfile.jazzy" ;;
         f ) DOCKERFILE="docker/Dockerfile.foxy" ;;
+        l ) DOCKERFILE="docker/Dockerfile.humble" ;;
         * ) usage; exit 1 ;;
     esac
 done


### PR DESCRIPTION

This PR adds support for building and running ROSplat with ROS 2 Humble.

### Changes
- Added `Dockerfile.humble` with CUDA 12.6 and ROS 2 Humble base
- Updated `run_docker.sh` to support `-l` flag for Humble
- Added missing Python and system dependencies
- Updated `docker-compose.yml` and requirements for compatibility

This allows running ROSplat in a ROS 2 Humble environment alongside existing Foxy and Jazzy setups.
